### PR TITLE
Pushes successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ install:
 
 script:
   - yarn test
+
+after_success:
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+      docker push nicholastmosher/ifad-backend ;
+    fi


### PR DESCRIPTION
This pushes an image if the build succeeds on master and needs to have DOCKER_USERNAME and DOCKER_PASSWORD defined as environment variables in Travis but I can't access the Travis repository settings in order to do so at the moment for some reason.