### PR TITLE
Add Dockerfile that pulls frontend and builds backend

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.idea
+.vscode
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM node:lts as build
+FROM nicholastmosher/ifad-frontend:latest AS frontend
 
-ADD ./ /proj_build
-WORKDIR /proj_build
+FROM node:lts as backend
+
+WORKDIR /ifad/backend
+COPY --from=frontend /frontend /ifad/frontend
+COPY . .
 
 RUN yarn
+
+ENV FRONTEND_PUBLIC_PATH /ifad/frontend
 RUN yarn build
-
-FROM node:lts
-
-COPY --from=build /proj_build /project
-WORKDIR /project
 
 CMD ["yarn", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  ifad-backend:
+    image: nicholastmosher/ifad-backend:latest
+    container_name: "ifad"
+    environment:
+      GENES_FILE: "/ifad/files/gene-types.txt"
+      ANNOTATIONS_FILE: "/ifad/files/gene_association.tair"
+    ports:
+      - 80:3000
+    volumes:
+      - "./src/assets:/ifad/files"

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,13 @@
 import express from "express";
 import { Server } from 'typescript-rest';
 import {V1Service} from "./services/v1_service/service";
+import {resolve} from "path";
 
 const app = express();
 
 Server.buildServices(app, V1Service);
+
+app.use(/\/$/, (req, res) => res.redirect("/app/"));
+app.use("/app/", express.static(process.env["FRONTEND_PUBLIC_PATH"] || resolve("../ifad-frontend/build")));
 
 export {app};


### PR DESCRIPTION
This Dockerfile pulls an image with the built static assets from the frontend hosted at `nicholastmosher/ifad-frontend:latest` and builds those together with the backend webserver. The backend image is published at `nicholastmosher/ifad-backend:latest`

You can now immediately launch the backend with the following command:

```
docker run -e ANNOTATIONS_FILE=/ifad/backend/src/assets/gene_association.tair -e GENES_FILE=/ifad/backend/src/assets/gene-types.txt -p3000:3000 -it nicholastmosher/ifad-backend:latest
```

Navigating to `http://localhost:3000` will direct you to the webapp, and the api is hosted at `http://localhost:3000/api`