### PR TITLE
Add metadata parsing for Genes

### DIFF
--- a/src/queries/__tests__/test_data.ts
+++ b/src/queries/__tests__/test_data.ts
@@ -238,7 +238,11 @@ export const structuredData: StructuredData = {
     records: annotationRecords,
     index: indexAnnotations(geneIndex, annotationRecords),
   },
-  geneIndex,
+  genes: {
+    metadata: "",
+    records: [],
+    index: geneIndex,
+  },
 };
 
 describe("the test data", () => {

--- a/src/queries/__tests__/test_queries.ts
+++ b/src/queries/__tests__/test_queries.ts
@@ -6,7 +6,7 @@ describe("Annotation queries", () => {
   it("should return all annotations and genes that appear in them with FilterGetAll", () => {
     const query: QueryGetAll = { tag: "QueryGetAll" };
 
-    const expectedGeneMap = Object.entries(structuredData.geneIndex)
+    const expectedGeneMap = Object.entries(structuredData.genes.index)
       // There is a specific gene which does not belong to any annotations called ATBLAHBLAH.
       // This query should have all of the genes except that one.
       .filter(([geneId, _]) => geneId !== "ATBLAHBLAH")

--- a/src/queries/queries.ts
+++ b/src/queries/queries.ts
@@ -91,7 +91,7 @@ const queryAll = (dataset: StructuredData): [GeneIndex, Annotation[]] => {
   );
 
   // Group all of the genes that appear in the annotations list.
-  const queriedGenes = Object.entries(dataset.geneIndex)
+  const queriedGenes = Object.entries(dataset.genes.index)
     .filter(([geneId, _]) => geneNamesInAnnotations.has(geneId))
     .reduce((acc, [geneId, gene]) => {
       acc[geneId] = gene;
@@ -127,7 +127,7 @@ const queryWithUnion = (
     queriedAnnotations.flatMap(a => [a.UniqueGeneName, ...a.AlternativeGeneName])
   );
 
-  const queriedGenes = Object.entries(dataset.geneIndex)
+  const queriedGenes = Object.entries(dataset.genes.index)
     .filter(([geneId, _]) => geneNamesInAnnotations.has(geneId))
     .reduce((acc, [geneId, gene]) => {
       acc[geneId] = gene;
@@ -149,7 +149,7 @@ const queryWithIntersection = (
   dataset: StructuredData,
   segments: Segment[],
 ): [GeneIndex, Annotation[]] => {
-  const queriedGeneMap = Object.entries(dataset.geneIndex)
+  const queriedGeneMap = Object.entries(dataset.genes.index)
     .filter(([_, { annotations }]) => {
 
       const gene_annotations = [...annotations];

--- a/src/services/v1_service/service.ts
+++ b/src/services/v1_service/service.ts
@@ -63,7 +63,7 @@ export class V1Service {
   @Path("/wgs_segments")
   @GET
   get_wgs() {
-    const totalGeneCount = Object.keys(dataset.geneIndex).length;
+    const totalGeneCount = Object.keys(dataset.genes.index).length;
 
     const result = Object.entries(dataset.annotations.index)
       .reduce((acc, [aspect, {all, known: {all: known_all, exp, other}, unknown}]) => {

--- a/src/services/v1_service/service.ts
+++ b/src/services/v1_service/service.ts
@@ -14,7 +14,7 @@ import {queryAnnotated, QueryOption, Segment, Strategy} from "../../queries/quer
 console.log("Begin reading data");
 const genesText = readFileSync(resolve("src/assets/gene-types.txt")).toString();
 const annotationsText = readFileSync(resolve("src/assets/gene_association.tair")).toString();
-const unstructuredText: UnstructuredText = { genesText, annotationsText };
+const unstructuredText: UnstructuredText = {genesText, annotationsText};
 const maybeDataset = ingestData(unstructuredText);
 if (!maybeDataset) throw new Error("failed to parse data");
 const dataset: StructuredData = maybeDataset;
@@ -23,62 +23,62 @@ console.log("Finished parsing data");
 @Path("/api/v1")
 export class V1Service {
 
-    @Path("/genes")
-    @GET
-    genes(
-        /**
-         * ?filter[]
-         * This query is used to generate a selection of genes and annotations
-         * according to which Aspect and Annotation Status they belong to.
-         */
-        @QueryParam("filter") maybeFilters: string[],
-        /**
-         * ?strategy
-         * This query parameter is used to choose whether genes and annotations
-         * are selected using a "union" strategy (where at least one filter must
-         * match) or using an "intersection" strategy (where all filters must
-         * match). The default value is "union".
-         */
-        @QueryParam("strategy") maybeStrategy: string = "union",
-    ) {
-        // Validate all of the filter query params. This throws a 400 if any are formatted incorrectly.
-        const segments: Segment[] = (maybeFilters || []).map(validateSegments);
+  @Path("/genes")
+  @GET
+  genes(
+    /**
+     * ?filter[]
+     * This query is used to generate a selection of genes and annotations
+     * according to which Aspect and Annotation Status they belong to.
+     */
+    @QueryParam("filter") maybeFilters: string[],
+    /**
+     * ?strategy
+     * This query parameter is used to choose whether genes and annotations
+     * are selected using a "union" strategy (where at least one filter must
+     * match) or using an "intersection" strategy (where all filters must
+     * match). The default value is "union".
+     */
+    @QueryParam("strategy") maybeStrategy: string = "union",
+  ) {
+    // Validate all of the filter query params. This throws a 400 if any are formatted incorrectly.
+    const segments: Segment[] = (maybeFilters || []).map(validateSegments);
 
-        let query: QueryOption;
-        if (segments.length === 0) {
-            query = { tag: "QueryGetAll" };
-        } else {
+    let query: QueryOption;
+    if (segments.length === 0) {
+      query = {tag: "QueryGetAll"};
+    } else {
 
-            // Validates the strategy query param string, which must be exactly "union" or "intersection".
-            const strategy: Strategy = validateStrategy(maybeStrategy);
-            query = { tag: "QueryWith", strategy, segments };
-        }
-
-        // TODO include unannotated genes
-        const [queriedGenes, queriedAnnotations] = queryAnnotated(dataset, query);
-
-        return {annotatedGenes: queriedGenes, annotations: queriedAnnotations, unannotatedGenes: []};
+      // Validates the strategy query param string, which must be exactly "union" or "intersection".
+      const strategy: Strategy = validateStrategy(maybeStrategy);
+      query = {tag: "QueryWith", strategy, segments};
     }
 
-    @Path("/wgs_segments")
-    @GET
-    get_wgs() {
-      const totalGeneCount = Object.keys(dataset.geneIndex).length;
+    // TODO include unannotated genes
+    const [queriedGenes, queriedAnnotations] = queryAnnotated(dataset, query);
 
-      const result = Object.entries(dataset.annotations.index)
-        .reduce((acc, [aspect, {all, known: {all: known_all, exp, other }, unknown}]) => {
-          acc[aspect].all = all.size;
-          acc[aspect].known.all = known_all.size;
-          acc[aspect].known.exp = exp.size;
-          acc[aspect].known.other = other.size;
-          acc[aspect].unknown = unknown.size;
-          acc[aspect].unannotated = totalGeneCount - all.size;
-          return acc;
+    return {annotatedGenes: queriedGenes, annotations: queriedAnnotations, unannotatedGenes: []};
+  }
+
+  @Path("/wgs_segments")
+  @GET
+  get_wgs() {
+    const totalGeneCount = Object.keys(dataset.geneIndex).length;
+
+    const result = Object.entries(dataset.annotations.index)
+      .reduce((acc, [aspect, {all, known: {all: known_all, exp, other}, unknown}]) => {
+        acc[aspect].all = all.size;
+        acc[aspect].known.all = known_all.size;
+        acc[aspect].known.exp = exp.size;
+        acc[aspect].known.other = other.size;
+        acc[aspect].unknown = unknown.size;
+        acc[aspect].unannotated = totalGeneCount - all.size;
+        return acc;
       }, makeAnnotationIndex(() => 0));
 
-      result["totalGenes"] = totalGeneCount;
-      return result;
-    }
+    result["totalGenes"] = totalGeneCount;
+    return result;
+  }
 }
 
 /**
@@ -86,7 +86,7 @@ export class V1Service {
  * @param maybeAspect The aspect query string being checked.
  */
 function validateAspect(maybeAspect: string): maybeAspect is Aspect {
-    return maybeAspect === "F" || maybeAspect === "C" || maybeAspect === "P";
+  return maybeAspect === "F" || maybeAspect === "C" || maybeAspect === "P";
 }
 
 /**
@@ -96,10 +96,10 @@ function validateAspect(maybeAspect: string): maybeAspect is Aspect {
  * @param maybeStatus
  */
 function validateAnnotationStatus(maybeStatus: string): maybeStatus is AnnotationStatus {
-    return maybeStatus === "EXP" ||
-        maybeStatus === "OTHER" ||
-        maybeStatus === "UNKNOWN" ||
-        maybeStatus === "UNANNOTATED";
+  return maybeStatus === "EXP" ||
+    maybeStatus === "OTHER" ||
+    maybeStatus === "UNKNOWN" ||
+    maybeStatus === "UNANNOTATED";
 }
 
 /**
@@ -115,20 +115,20 @@ function validateAnnotationStatus(maybeStatus: string): maybeStatus is Annotatio
  * @param maybeFilter The string which we are checking is a valid filter.
  */
 function validateSegments(maybeFilter: string): Segment {
-    const parts = maybeFilter.split(",");
-    if (parts.length !== 2) {
-        throw new Errors.BadRequestError("each filter must have exactly two parts, an Aspect and an Annotation Status, separated by a comma");
-    }
+  const parts = maybeFilter.split(",");
+  if (parts.length !== 2) {
+    throw new Errors.BadRequestError("each filter must have exactly two parts, an Aspect and an Annotation Status, separated by a comma");
+  }
 
-    const [aspect, annotationStatus] = parts;
-    if (!validateAspect(aspect)) {
-        throw new Errors.BadRequestError("the Aspect given in a filter must be exactly 'P', 'C', or 'F'");
-    }
-    if (!validateAnnotationStatus(annotationStatus)) {
-        throw new Errors.BadRequestError("the Annotation Status given in a filter must be exactly 'EXP', 'OTHER', 'UNKNOWN', or 'UNANNOTATED'");
-    }
+  const [aspect, annotationStatus] = parts;
+  if (!validateAspect(aspect)) {
+    throw new Errors.BadRequestError("the Aspect given in a filter must be exactly 'P', 'C', or 'F'");
+  }
+  if (!validateAnnotationStatus(annotationStatus)) {
+    throw new Errors.BadRequestError("the Annotation Status given in a filter must be exactly 'EXP', 'OTHER', 'UNKNOWN', or 'UNANNOTATED'");
+  }
 
-    return {aspect, annotationStatus};
+  return {aspect, annotationStatus};
 }
 
 /**
@@ -140,8 +140,8 @@ function validateSegments(maybeFilter: string): Segment {
  * @param maybeStrategy "union" | "intersection"
  */
 function validateStrategy(maybeStrategy: string): Strategy {
-    if (maybeStrategy !== "union" && maybeStrategy !== "intersection") {
-        throw new Errors.BadRequestError("strategy must be either 'union' or 'intersection'");
-    }
-    return maybeStrategy;
+  if (maybeStrategy !== "union" && maybeStrategy !== "intersection") {
+    throw new Errors.BadRequestError("strategy must be either 'union' or 'intersection'");
+  }
+  return maybeStrategy;
 }

--- a/src/utils/__tests__/test_ingest.ts
+++ b/src/utils/__tests__/test_ingest.ts
@@ -1,4 +1,4 @@
-import {parseAnnotationsData, parseGenesData, splitAnnotationsText} from "../ingest";
+import {parseAnnotationsData, parseGenesData, splitMetadataText} from "../ingest";
 
 const gene_data = `
 AT1G01010	protein_coding
@@ -85,9 +85,9 @@ TAIR	locus:2125359	CTU2		GO:0000049	TAIR:AnalysisReference:501756966	IEA	InterPr
 TAIR	locus:2136328	AT4G39280		GO:0000049	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR002319	F	AT4G39280	AT4G39280|T22F8.180|T22F8_180	protein	taxon:3702	20190907	InterPro		TAIR:locus:2136328
 TAIR	locus:2143266	TRM1b		GO:0000049	TAIR:AnalysisReference:501756968	IEA	UniProtKB-KW:KW-0820	F	AT5G15810	AT5G15810|TRM1b|AtTRM1b|tRNA methyltransferase 1b|F14F8.190|F14F8_190	protein	taxon:3702	20190907	UniProt		TAIR:locus:2143266`;
 
-    const result = splitAnnotationsText(raw_annotation_text);
+    const result = splitMetadataText(raw_annotation_text);
     if (!result) fail("test data should split correctly");
-    const { metadataText, annotationsText } = result;
+    const { metadataText, bodyText } = result;
 
     const expected_metadata = `!gaf-version: 2.1
 !
@@ -132,7 +132,7 @@ TAIR	locus:2124519	AT4G18460		GO:0000049	TAIR:AnalysisReference:501756970	IEA	Un
 TAIR	locus:2125359	CTU2		GO:0000049	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR019407	F	AT4G35910	AT4G35910|CTU2|CYTOPLASMIC THIOURIDYLASE 2|T19K4.40	protein	taxon:3702	20190601	InterPro		TAIR:locus:2125359
 TAIR	locus:2136328	AT4G39280		GO:0000049	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR002319	F	AT4G39280	AT4G39280|T22F8.180|T22F8_180	protein	taxon:3702	20190907	InterPro		TAIR:locus:2136328
 TAIR	locus:2143266	TRM1b		GO:0000049	TAIR:AnalysisReference:501756968	IEA	UniProtKB-KW:KW-0820	F	AT5G15810	AT5G15810|TRM1b|AtTRM1b|tRNA methyltransferase 1b|F14F8.190|F14F8_190	protein	taxon:3702	20190907	UniProt		TAIR:locus:2143266`;
-    expect(annotationsText).toEqual(expected_annotations);
+    expect(bodyText).toEqual(expected_annotations);
 
   });
 
@@ -157,9 +157,9 @@ TAIR	locus:2043067	ENOC		GO:0000015	TAIR:AnalysisReference:501756966	IEA	InterPr
 TAIR	locus:2044851	LOS2		GO:0000015	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR000941	C	AT2G36530	AT2G36530|LOS2|ENO2|LOW EXPRESSION OF OSMOTICALLY RESPONSIVE GENES 2|enolase 2|F1O11.16|F1O11_16	protein	taxon:3702	20190408	InterPro		TAIR:locus:2044851
 TAIR	locus:2032970	AT1G25260		GO:0000027	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR033867	P	AT1G25260	AT1G25260|F4F7.35|F4F7_35	protein	taxon:3702	20190404	InterPro		TAIR:locus:2032970`;
 
-    const result = splitAnnotationsText(raw_annotation_text);
+    const result = splitMetadataText(raw_annotation_text);
     if (!result) fail("test data should split correctly");
-    const { metadataText, annotationsText } = result;
+    const { metadataText, bodyText } = result;
 
     const expected_metadata = `
 
@@ -185,7 +185,7 @@ TAIR	locus:2043067	ENOC		GO:0000015	TAIR:AnalysisReference:501756966	IEA	InterPr
 TAIR	locus:2044851	LOS2		GO:0000015	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR000941	C	AT2G36530	AT2G36530|LOS2|ENO2|LOW EXPRESSION OF OSMOTICALLY RESPONSIVE GENES 2|enolase 2|F1O11.16|F1O11_16	protein	taxon:3702	20190408	InterPro		TAIR:locus:2044851
 TAIR	locus:2032970	AT1G25260		GO:0000027	TAIR:AnalysisReference:501756966	IEA	InterPro:IPR033867	P	AT1G25260	AT1G25260|F4F7.35|F4F7_35	protein	taxon:3702	20190404	InterPro		TAIR:locus:2032970`;
 
-    expect(annotationsText).toEqual(expected_annotations);
+    expect(bodyText).toEqual(expected_annotations);
   });
 
 });

--- a/src/utils/ingest.ts
+++ b/src/utils/ingest.ts
@@ -279,7 +279,7 @@ export const makeAnnotationIndex = <T>(initial: () => T): AnnotationIndex<T> => 
  * @param annotationData The parsed annotation data.
  */
 export const indexAnnotations = (
-  geneIndex: GeneIndex, 
+  geneIndex: GeneIndex,
   annotationData: Annotation[]
 ): AnnotationIndex<Set<Gene>> => {
 
@@ -371,5 +371,5 @@ export const ingestData = (raw: UnstructuredText): StructuredData | null => {
   };
 
   // Return all structured data
-  return { geneIndex, annotations, raw };
+  return {geneIndex, annotations, raw};
 };


### PR DESCRIPTION
Previously I didn't realize that Genes also may have metadata included in their header. Luckily the genes files use the same strategy of leading metadata lines with `!`, so we can use the same functions for parsing that metadata.