### PR TITLE
Query correctness

### DIFF
--- a/src/queries/__tests__/test_data.ts
+++ b/src/queries/__tests__/test_data.ts
@@ -277,14 +277,17 @@ const annotationRecords: Annotation[] = Object.entries(geneIndex)
   .flatMap(([_, value]) => [...value.annotations]);
 
 export const structuredData: StructuredData = {
-  raw: { genesText: "", annotationsText: "" },
+  raw: {
+    genesText: "genes raw data",
+    annotationsText: "annotations raw data",
+  },
   annotations: {
-    metadata: "",
+    metadata: "!annotation metadata",
     records: annotationRecords,
     index: indexAnnotations(geneIndex, annotationRecords),
   },
   genes: {
-    metadata: "",
+    metadata: "!gene metadata",
     records: [],
     index: geneIndex,
   },

--- a/src/queries/__tests__/test_queries.ts
+++ b/src/queries/__tests__/test_queries.ts
@@ -7,7 +7,7 @@ describe("Annotation queries", () => {
   it("should return all annotations and genes that appear in them with FilterGetAll", () => {
     const query: QueryGetAll = { tag: "QueryGetAll" };
 
-    const expectedGeneMap = Object.entries(structuredData.genes.index)
+    const expectedGeneIndex = Object.entries(structuredData.genes.index)
       // There is a specific gene which does not belong to any annotations called ATBLAHBLAH.
       // This query should have all of the genes except that one.
       .filter(([geneId, _]) => geneId !== "ATBLAHBLAH")
@@ -16,8 +16,13 @@ describe("Annotation queries", () => {
         return acc;
       }, {});
 
+    const expectedQueryResult = {
+      genes: expectedGeneIndex,
+      annotations: structuredData.annotations.records,
+    };
+
     expect(queryAnnotated(structuredData, query))
-      .toEqual([expectedGeneMap, structuredData.annotations.records]);
+      .toEqual(expectedQueryResult);
   });
 
   it("should choose the proper subset for FilterWith:union for C:KNOWN_EXP", () => {
@@ -26,7 +31,7 @@ describe("Annotation queries", () => {
       segments: [{ aspect: "C", annotationStatus: "KNOWN_EXP" }],
     };
 
-    const expectedGeneMap = {
+    const expectedGeneIndex = {
       AT4G18120: {
         gene: {
           GeneID: "AT4G18120",
@@ -90,8 +95,13 @@ describe("Annotation queries", () => {
         GeneProductFormID: '' }
     ];
 
+    const expectedQueryResult = {
+      genes: expectedGeneIndex,
+      annotations: expectedAnnotations,
+    };
+
     expect(queryAnnotated(structuredData, query))
-      .toEqual([expectedGeneMap, expectedAnnotations]);
+      .toEqual(expectedQueryResult);
   });
 
   it("should choose a proper subset for FilterWith:union for C:KNOWN_OTHER", () => {
@@ -100,7 +110,7 @@ describe("Annotation queries", () => {
       segments: [{ aspect: "C", annotationStatus: "KNOWN_OTHER" }],
     };
 
-    const expectedGeneMap: GeneIndex = {
+    const expectedGeneIndex: GeneIndex = {
       AT1G09440: {
         gene: {
           GeneID: "AT1G09440",
@@ -212,8 +222,13 @@ describe("Annotation queries", () => {
         GeneProductFormID: '' },
     ];
 
+    const expectedQueryResult = {
+      genes: expectedGeneIndex,
+      annotations: expectedAnnotations,
+    };
+
     expect(queryAnnotated(structuredData, query))
-      .toEqual([expectedGeneMap, expectedAnnotations]);
+      .toEqual(expectedQueryResult);
   });
 
   it("should return the union of results when using FilterWith:union for C:KNOWN_OTHER,P:KNOWN_OTHER", () => {
@@ -225,7 +240,7 @@ describe("Annotation queries", () => {
       ],
     };
 
-    const expectedGeneMap: GeneIndex = {
+    const expectedGeneIndex: GeneIndex = {
       AT1G09440: {
         gene: {
           GeneID: "AT1G09440",
@@ -574,12 +589,12 @@ describe("Annotation queries", () => {
     ];
 
     // Convert annotations lists to Sets in order to compare contents without order.
-    const [outputGeneMap, outputAnnotations] = queryAnnotated(structuredData, query);
-    const outputAnnotationsSet = new Set(outputAnnotations);
+    const { genes, annotations } = queryAnnotated(structuredData, query);
+    const outputAnnotationsSet = new Set(annotations);
     const expectedAnnotationsSet = new Set(expectedAnnotations);
 
-    expect([outputGeneMap, outputAnnotationsSet])
-      .toEqual([expectedGeneMap, expectedAnnotationsSet]);
+    expect([genes, outputAnnotationsSet])
+      .toEqual([expectedGeneIndex, expectedAnnotationsSet]);
   });
 
   it("should find a single gene for QueryWith:intersection for C:KNOWN_OTHER,P:KNOWN_OTHER", () => {
@@ -591,7 +606,7 @@ describe("Annotation queries", () => {
       ],
     };
 
-    const expectedGeneMap: GeneIndex = {
+    const expectedGeneIndex: GeneIndex = {
       AT1G08845: {
         gene: {
           GeneID: "AT1G08845",
@@ -641,8 +656,12 @@ describe("Annotation queries", () => {
     };
 
     const expectedAnnotations = [];
+    const expectedQueryResult = {
+      genes: expectedGeneIndex,
+      annotations: expectedAnnotations,
+    };
 
     expect(queryAnnotated(structuredData, query))
-      .toEqual([expectedGeneMap, expectedAnnotations]);
+      .toEqual(expectedQueryResult);
   });
 });

--- a/src/queries/__tests__/test_queries.ts
+++ b/src/queries/__tests__/test_queries.ts
@@ -1,13 +1,13 @@
 import { structuredData } from "./test_data";
 import {QueryGetAll, QueryWith, queryAnnotated, QueryOption} from "../queries";
-import {Annotation, GeneIndex} from "../../utils/ingest";
+import {Annotation, GeneIndex, indexAnnotations, StructuredData} from "../../utils/ingest";
 
 describe("Annotation queries", () => {
 
   it("should return all annotations and genes that appear in them with FilterGetAll", () => {
     const query: QueryGetAll = { tag: "QueryGetAll" };
 
-    const expectedGeneIndex = Object.entries(structuredData.genes.index)
+    const expectedGeneIndex: GeneIndex = Object.entries(structuredData.genes.index)
       // There is a specific gene which does not belong to any annotations called ATBLAHBLAH.
       // This query should have all of the genes except that one.
       .filter(([geneId, _]) => geneId !== "ATBLAHBLAH")
@@ -16,13 +16,9 @@ describe("Annotation queries", () => {
         return acc;
       }, {});
 
-    const expectedQueryResult = {
-      genes: expectedGeneIndex,
-      annotations: structuredData.annotations.records,
-    };
-
-    expect(queryAnnotated(structuredData, query))
-      .toEqual(expectedQueryResult);
+    const queryResult = queryAnnotated(structuredData, query);
+    expect(queryResult.genes.index).toEqual(expectedGeneIndex);
+    expect(queryResult.annotations.records).toEqual(structuredData.annotations.records);
   });
 
   it("should choose the proper subset for FilterWith:union for C:KNOWN_EXP", () => {
@@ -95,13 +91,9 @@ describe("Annotation queries", () => {
         GeneProductFormID: '' }
     ];
 
-    const expectedQueryResult = {
-      genes: expectedGeneIndex,
-      annotations: expectedAnnotations,
-    };
-
-    expect(queryAnnotated(structuredData, query))
-      .toEqual(expectedQueryResult);
+    const queryResult = queryAnnotated(structuredData, query);
+    expect(queryResult.genes.index).toEqual(expectedGeneIndex);
+    expect(queryResult.annotations.records).toEqual(expectedAnnotations);
   });
 
   it("should choose a proper subset for FilterWith:union for C:KNOWN_OTHER", () => {
@@ -222,13 +214,9 @@ describe("Annotation queries", () => {
         GeneProductFormID: '' },
     ];
 
-    const expectedQueryResult = {
-      genes: expectedGeneIndex,
-      annotations: expectedAnnotations,
-    };
-
-    expect(queryAnnotated(structuredData, query))
-      .toEqual(expectedQueryResult);
+    const queryResult = queryAnnotated(structuredData, query);
+    expect(queryResult.genes.index).toEqual(expectedGeneIndex);
+    expect(queryResult.annotations.records).toEqual(expectedAnnotations);
   });
 
   it("should return the union of results when using FilterWith:union for C:KNOWN_OTHER,P:KNOWN_OTHER", () => {
@@ -589,8 +577,9 @@ describe("Annotation queries", () => {
     ];
 
     // Convert annotations lists to Sets in order to compare contents without order.
-    const { genes, annotations } = queryAnnotated(structuredData, query);
-    const outputAnnotationsSet = new Set(annotations);
+    const queriedDataset = queryAnnotated(structuredData, query);
+    const genes = queriedDataset.genes.index;
+    const outputAnnotationsSet = new Set(queriedDataset.annotations.records);
     const expectedAnnotationsSet = new Set(expectedAnnotations);
 
     expect([genes, outputAnnotationsSet])
@@ -655,13 +644,9 @@ describe("Annotation queries", () => {
       },
     };
 
+    const queryResult = queryAnnotated(structuredData, query);
     const expectedAnnotations = [];
-    const expectedQueryResult = {
-      genes: expectedGeneIndex,
-      annotations: expectedAnnotations,
-    };
-
-    expect(queryAnnotated(structuredData, query))
-      .toEqual(expectedQueryResult);
+    expect(queryResult.genes.index).toEqual(expectedGeneIndex);
+    expect(queryResult.annotations.records).toEqual(expectedAnnotations);
   });
 });

--- a/src/services/v1_service/service.ts
+++ b/src/services/v1_service/service.ts
@@ -70,27 +70,30 @@ export class V1Service {
     }
 
     // TODO include unannotated genes
-    const [queriedGenes, queriedAnnotations] = queryAnnotated(dataset, query);
+    const queriedDataset = queryAnnotated(dataset, query);
 
     // TODO include unannotated genes
     const format = validateFormat(maybeFormat);
     switch (format) {
       case "gaf":
-        const gafFileStream = annotationsToGAF(dataset, {filters: segments.map(f=>`${f.aspect}-${f.annotationStatus}`).join(", ")});
+        const gafFileStream = annotationsToGAF(queriedDataset, {filters: segments.map(f=>`${f.aspect}-${f.annotationStatus}`).join(", ")});
         response.status(200);
         response.setHeader("Content-Type", "application/csv");
         response.setHeader("Content-disposition", "attachment;filename=gene-association.gaf");
         gafFileStream.pipe(response);
         return Return.NoResponse;
       case "gene-csv":
-        const csvFileStream = genesToCSV(dataset, {filters: segments.map(f=>`${f.aspect}-${f.annotationStatus}`).join(", ")});
+        const csvFileStream = genesToCSV(queriedDataset, {filters: segments.map(f=>`${f.aspect}-${f.annotationStatus}`).join(", ")});
         response.status(200);
         response.setHeader("Content-Type", "application/csv");
         response.setHeader("Content-disposition", "attachment;filename=gene-types.csv");
         csvFileStream.pipe(response);
         return Return.NoResponse;
       case "json":
-        return {annotatedGenes: queriedGenes, annotations: queriedAnnotations, unannotatedGenes: []};
+        return {
+          genes: queriedDataset.genes.records,
+          annotations: queriedDataset.annotations.records,
+        };
     }
   }
 

--- a/src/utils/ingest.ts
+++ b/src/utils/ingest.ts
@@ -355,7 +355,7 @@ export const makeAnnotationIndex = <T>(initial: () => T): AnnotationIndex<T> => 
 export const indexAnnotations = (
   geneIndex: GeneIndex,
   annotationData: Annotation[]
-): AnnotationIndex<Set<string>> => {
+): AnnotationIndex => {
 
   // Index all annotations based on aspect, categorizing KNOWN_EXP but not KNOWN_OTHER
   const expAndUnknownIndex: AnnotationIndex<Set<string>> = annotationData


### PR DESCRIPTION
A few changes happened here:

* Updated the indexing step to categorize Unannotated genes
* Restructured compound queries (e.g. queryUnion) in terms of the new querySegment
* Restructured the output type of queries to match StructuredData to allow passing directly to export

Haven't gotten to do crazy battle-testing on it yet, but all of the test cases continue to work with nothing except some restructuring.